### PR TITLE
Add scorpio dependancy check

### DIFF
--- a/civet/command.py
+++ b/civet/command.py
@@ -176,6 +176,8 @@ Default: `the_usual`""")
         sys.exit(0)
 
     dependency_checks.check_dependencies(dependency_list, module_list)
+    if args.mutations:
+        dependency_checks.check_scorpio_mutations(args.mutations)
     
     # Initialise config dict
     config = init.setup_config_dict(cwd,args.config)

--- a/civet/utils/dependency_checks.py
+++ b/civet/utils/dependency_checks.py
@@ -48,5 +48,22 @@ def check_dependencies(dependency_list, module_list):
     else:
         print(green("All dependencies satisfied."))
 
+def check_scorpio_mutations(comma_separated_mutations):
+    mutations = " ".join(comma_separated_mutations.split(","))
+    test_fasta = os.path.join("../tests/action_test_data/civet_test.fa")
+    command = "scorpio haplotype \
+                  -i %s \
+                  --mutations %s \
+                  --append-genotypes \
+                  -n mutations \
+                  --dry-run" % (test_fasta, mutations)
+    completed_process = subprocess.run(command, shell=True, stderr=subprocess.PIPE, stdout=subprocess.PIPE,
+                                           universal_newlines=True)
+    if completed_process.returncode != 0:
+        sys.stderr.write(cyan(
+            f'Error: Scorpio does not like your mutations\n%s' % completed_process.stderr))
+        sys.exit(-1)
+    else:
+        print(green("Scorpio mutations are in approved format."))
 
 # check_dependencies()

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(name='civet',
             "civet/scripts/scorpio_runner.smk",
             "civet/scripts/generate_background_data.smk"
             ],
-      package_data={"civet":["data/*","data/report_modules/*","data/map_data/*"]},
+      package_data={"civet":["data/*","data/report_modules/*","data/map_data/*","tests/action_test_data/*.fa"]},
       install_requires=[
             "biopython>=1.70",
             "mako>=1.1",


### PR DESCRIPTION
Adds a function to dependancy checks which runs scorpio in new `--dry-run` mode to check if input mutations are in an acceptable format, quitting with the error to stderr if not