### PR TITLE
--global_snipit to summarise SNP diversity for all query sequences

### DIFF
--- a/civet/command.py
+++ b/civet/command.py
@@ -45,6 +45,13 @@ def main(sysargs = sys.argv[1:]):
     i_group.add_argument('-f','--input-sequences', action="store",help="Optional fasta file. Sequence IDs must match to a query ID specified either in the input csv or ID string", dest="input_sequences")
     i_group.add_argument('-fm','--from-metadata',nargs='*', dest="from_metadata",help="Generate a query from the metadata file supplied. Define a search that will be used to pull out sequences of interest from the background data. Example: -fm country=Ireland sample_date=2020-03-01:2020-04-01")
     i_group.add_argument('-mq','--max-queries', type=int, action="store",dest="max_queries",help="Max number of queries. Default: `5000`")
+    i_group.add_argument('--global_snipit', action="store_true",
+                              help="Create a global snipit figure for all focal sequences", dest="global_snipit")
+    i_group.add_argument('--focal_alignment', action="store",
+                            help="Optional alignment of focal sequences for global snipit", dest="focal_alignment")
+    i_group.add_argument('--reference_name', action="store",
+                         help="Optional input for the reference name in the focal alignment. Default: Reference",
+                         dest="reference_name")
 
     ic_group = parser.add_argument_group('Input column configuration')
     ic_group.add_argument('-icol',"--input-id-column", action="store", dest="input_id_column",help="Column in input csv file to match with database. Default: `name`")
@@ -212,6 +219,7 @@ Default: `the_usual`""")
 
         return 1
 
+
     # Checks background data exists and is the right format.
     # Checks same number of records supplied for csv, fasta and (optional) SNP file. 
     data_arg_parsing.data_group_parsing(args.debug,args.datadir,args.background_metadata,args.background_snps,args.background_sequences,args.background_tree,args.background_id_column,args.sequence_id_column,config)
@@ -270,7 +278,8 @@ Default: `the_usual`""")
        return 0
 
     return 1
-    
+
+
 
 if __name__ == '__main__':
     main()

--- a/civet/data/report_modules/report_template.mako
+++ b/civet/data/report_modules/report_template.mako
@@ -859,8 +859,36 @@
             </table>
           </div>
         %endif
+	<% figure_count = 0 %>
+        %if config["global_snipit"]:
+	<h2>global snipit </h2>
+	<h3>SNP summary for all query sequences relative to the reference </h3>
+	<% figure_count +=1 %>
+        <br>
+        <button class="accordion">Export image</button>
+          <div class="panel">
+            <div class="row">
+              <div class="column">
+                <button id="global_snipit_svg">SVG</button>
+              </div>
+              <div class="column">
+                <button id="global_snipit_png">PNG</button>
+              </div>
+            </div>
+          </div>
+            <div id="global_snipit">
+            ${data_for_report["global_snipit_svg"]}
+            </div>
+      <script type="text/javascript">
+        exportImageSVG("global_snipit_svg","global_snipit");
+      </script>
+      <script type="text/javascript">
+        exportImagePNG("global_snipit_png","global_snipit");
+      </script>
+            <h3><strong>Figure ${figure_count}</strong> | snipit plot for all focal query sequences</h3>
+            <hr>        
+        %endif
   %endif
-    <% figure_count = 0 %>
     %for catchment in catchments:
         <% catchment_name = catchment.replace("_"," ").title() %>
         <h2><a id = "header_${catchment}"></a>${catchment_name}</h2> 

--- a/civet/data/report_modules/report_template.mako
+++ b/civet/data/report_modules/report_template.mako
@@ -880,10 +880,10 @@
             ${data_for_report["global_snipit_svg"]}
             </div>
       <script type="text/javascript">
-        exportImageSVG("global_snipit_svg","global_snipit");
+        exportImageSVG("#global_snipit_svg","#global_snipit", "global_snipit_chart");
       </script>
       <script type="text/javascript">
-        exportImagePNG("global_snipit_png","global_snipit");
+        exportImagePNG("#global_snipit_png","#global_snipit", "global_snipit_chart");
       </script>
             <h3><strong>Figure ${figure_count}</strong> | snipit plot for all focal query sequences</h3>
             <hr>        

--- a/civet/input_parsing/initialising.py
+++ b/civet/input_parsing/initialising.py
@@ -20,7 +20,10 @@ def get_defaults():
                     #input cols
                     KEY_INPUT_ID_COLUMN:"name",
                     KEY_INPUT_DATE_COLUMN:False, #default is sample_date if present in the input csv
-                    KEY_INPUT_DISPLAY_COLUMN: False,
+                    KEY_INPUT_DISPLAY_COLUMN:False,
+                    KEY_GLOBAL_SNIPIT: False,
+                    KEY_FOCAL_ALIGNMENT:"",
+                    KEY_REFERENCE_NAME:"reference",
 
                     # input seq options 
                     KEY_NUM_SEQS:0,
@@ -147,6 +150,9 @@ def arg_dict(config):
                 "from_metadata":"from_metadata",
                 "max_queries":"max_queries",
                 "mq":"max_queries",
+                "global_snipit": "global_snipit",
+                "focal_alignment": "focal_alignment",
+                "reference_name": "reference_name",
 
                 # ic group args
                 "icol":"input_id_column",

--- a/civet/report_functions/report.py
+++ b/civet/report_functions/report.py
@@ -195,6 +195,14 @@ def get_background_data(metadata,config):
     data = json.dumps(background_data) 
     return data
 
+def get_global_snipit(data_for_report,config):
+    global_snipit_svg = ""
+    with open(os.path.join(config["tempdir"],"snipit", "global_snipit.svg"),"r") as f:
+        for l in f:
+            l = l.rstrip("\n")
+            global_snipit_svg+=f"{l}\n"
+    data_for_report["global_snipit_svg"] = global_snipit_svg
+
 
 def define_report_content(metadata,catchments,figure_catchments,config):
     report_content = config[KEY_REPORT_CONTENT]
@@ -257,6 +265,9 @@ def define_report_content(metadata,catchments,figure_catchments,config):
         data_for_report["query_map_data"] = get_query_map(config)
     else:
         data_for_report["query_map_data"] = ""
+
+    if config[KEY_GLOBAL_SNIPIT]:
+        get_global_snipit(data_for_report, config)
     
     return data_for_report
 
@@ -299,4 +310,4 @@ def make_report(metadata,report_to_generate,config):
     with open(report_to_generate, 'w') as fw:
         print(green("Generating: ") + f"{report_to_generate}")
         fw.write(buf.getvalue())
-    
+

--- a/civet/scripts/civet.smk
+++ b/civet/scripts/civet.smk
@@ -252,12 +252,36 @@ rule snipit:
             shell("touch {output.txt:q}")
 
 
+rule global_snipit:
+    input:
+        fasta = rules.align_to_reference.output.fasta,
+	yaml = rules.merge_catchments.output.yaml,
+	prompt = rules.snipit.output.txt,
+        snakefile = os.path.join(workflow.current_basedir,"global_snipit.smk")
+    output:
+        txt = os.path.join(config[KEY_TEMPDIR],"global_snipit","prompt.txt")
+    run:
+        if config[KEY_GLOBAL_SNIPIT]:
+            print(green("Running global snipit"))
+            # spawn off global snipit
+            shell("snakemake --nolock --snakefile {input.snakefile:q} "
+                    "--forceall "
+                    "{config[log_string]} "
+                    "--directory {config[tempdir]:q} "
+		    "--configfile {input.yaml:q} "
+                    "--config fasta={input.fasta:q} "
+                    "--cores {workflow.cores} && touch {output.txt:q}")
+        else:
+            shell("touch {output.txt:q}")
+
+
 rule render_report:
     input:
         csv = rules.scorpio_type.output.csv,
         yaml = rules.merge_catchments.output.yaml,
         snipit = rules.snipit.output.txt,
-        trees = rules.tree_building.output.txt
+        trees = rules.tree_building.output.txt,
+	global_snipit = rules.global_snipit.output.txt
     output:
         html = os.path.join(config[KEY_OUTDIR],config[KEY_OUTPUT_REPORTS][0])
     run:

--- a/civet/scripts/global_snipit.smk
+++ b/civet/scripts/global_snipit.smk
@@ -1,0 +1,77 @@
+from civet.utils.log_colours import green,cyan,red
+from civet.analysis_functions import catchment_parsing
+from civet.utils import misc
+from civet.report_functions import report
+from Bio import Phylo
+from Bio import SeqIO
+import csv
+import collections
+from civet.utils.config import *
+
+rule all:
+    input:
+        os.path.join(config["tempdir"], "snipit", "global_snipit_labels.txt"),
+	os.path.join(config["tempdir"],"snipit", "global_snipit.svg")
+
+rule gather_focal_seqs: 
+    input: 
+        outgroup_fasta = config[KEY_REFERENCE_SEQUENCE],
+        focal_align = config["fasta"]
+    output: 
+        full_aln = os.path.join(config["tempdir"],"all_focal_aln.fasta")
+    run: 
+        with open(output.full_aln, "w") as handle: 
+            for record in SeqIO.parse(input.outgroup_fasta, "fasta"):
+                handle.write(f">Reference\n{record.seq}\n")
+            for record in SeqIO.parse(input.focal_align, "fasta"):
+                handle.write(f">{record.description}\n{record.seq}\n")
+
+
+if not config["focal_alignment"]:
+    ALIGN = config["fasta"]
+else: 
+    ALIGN = config["focal_alignment"]
+
+rule get_all_sequence_names:
+    input:
+        alignment = ALIGN
+    output:
+        seq_names = os.path.join(config["tempdir"], "snipit", "global_snipit_labels.txt")
+	
+    params: 
+        ref_name = config[KEY_REFERENCE_SEQUENCE]
+    run:
+        ref_done = "no"
+       
+        record_names = []
+        fasta_sequences = SeqIO.parse(open(input.alignment), 'fasta')
+        for record in fasta_sequences:
+            record_names.append(record.name)
+        with open(output.seq_names, "w") as handle:
+            handle.write(f"name,label\n")
+            if params.ref_name in record_names: 
+                handle.write(f"{params.ref_name},Reference\n")
+                ref_name = params.ref_name
+                ref_done = "yes"
+            for i in record_names: 
+                 if i not in params.ref_name and ref_done == "no":
+                     handle.write(f"{i},Reference\n")
+                     ref_done = "yes"
+                 elif i not in params.ref_name:
+                     handle.write(f"{i},{i}\n")
+                 else:
+                     pass
+
+rule snipit_all:
+    input:
+        aln = ALIGN,
+	names = rules.get_all_sequence_names.output.seq_names
+    params:
+        out_path = os.path.join(config["tempdir"],"snipit", "global_snipit")
+    output:
+        os.path.join(config["tempdir"],"snipit", "global_snipit.svg")
+    shell:
+        """
+        snipit {input.aln:q} -o {params.out_path} -l {input.names} -r $(grep "Reference" {input.names} | head -n 1 | cut -d, -f1) -f svg
+        """
+

--- a/civet/scripts/global_snipit.smk
+++ b/civet/scripts/global_snipit.smk
@@ -28,7 +28,7 @@ rule gather_focal_seqs:
 
 
 if not config["focal_alignment"]:
-    ALIGN = config["fasta"]
+    ALIGN = rules.gather_focal_seqs.output.full_aln
 else: 
     ALIGN = config["focal_alignment"]
 
@@ -39,7 +39,7 @@ rule get_all_sequence_names:
         seq_names = os.path.join(config["tempdir"], "snipit", "global_snipit_labels.txt")
 	
     params: 
-        ref_name = config[KEY_REFERENCE_SEQUENCE]
+        ref_name = config[KEY_REFERENCE_NAME]
     run:
         ref_done = "no"
        

--- a/civet/utils/config.py
+++ b/civet/utils/config.py
@@ -11,6 +11,9 @@ KEY_MAX_QUERIES="max_queries"
 KEY_INPUT_ID_COLUMN="input_id_column"
 KEY_INPUT_DATE_COLUMN="input_date_column"
 KEY_INPUT_DISPLAY_COLUMN="input_display_column"
+KEY_GLOBAL_SNIPIT="global_snipit"
+KEY_FOCAL_ALIGNMENT="focal_alignment"
+KEY_REFERENCE_NAME="reference_name"
 
 # INPUT SEQ OPTION KEYS
 KEY_INPUT_SEQUENCES="input_sequences"

--- a/civet/utils/data_install_checks.py
+++ b/civet/utils/data_install_checks.py
@@ -35,3 +35,11 @@ def check_install(config):
 
 # config={}
 # check_install()
+
+def get_global_snipit_snakefile(thisdir):
+    snakefile = os.path.join(thisdir, 'scripts','global_snipit.smk')
+    if not os.path.exists(snakefile):
+        sys.stderr.write(cyan(f'Error: cannot find Snakefile at {snakefile}\n Check installation\n'))
+        sys.exit(-1)
+    return snakefile
+

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,8 @@ setup(name='civet',
             "civet/scripts/build_catchment_trees.smk",
             "civet/scripts/snipit_runner.smk",
             "civet/scripts/scorpio_runner.smk",
-            "civet/scripts/generate_background_data.smk"
+            "civet/scripts/generate_background_data.smk",
+            "civet/scripts/global_snipit.smk"
             ],
       package_data={"civet":["data/*","data/report_modules/*","data/map_data/*","tests/action_test_data/*.fa"]},
       install_requires=[


### PR DESCRIPTION
This PR is a functional duplicate of the one originally opened in civet 2: https://github.com/artic-network/civet/pull/131, and has been modified to be compatible with civet 3. 

The CLI argument --global_snipit allows the user to add an optional snipit graph to summarise all of the query sequences together. The default behaviour is to not include. If selected, the snipit graph for all sequences is inserted just below the summary table (see attached image below for an example using de-identified COVID samples).

The user has the option for what alignment input to use. If no alignment is provided, it will use the alignment created by minimap2 and the reference sequence found in the data directory. Otherwise, the user can specify their own input using --focal_alignment. 

The workflow is compatible with the way that snipit searches for the reference. The reference name can be specified by the user using reference_name if a custom alignment is used, or the first entry in the alignment will be selected if no name is provided. If the alignment is created for them, this doesn't apply, and the reference is simply labelled as the outgroup fasta 'Reference".

Similar to the other graphics, the global snipit graph can be exported in either SVG or PNG format. 

![Screenshot from 2021-09-01 10-34-59](https://user-images.githubusercontent.com/40243147/131692816-e44946d8-c88b-4357-8a54-616c9c951a59.png)


